### PR TITLE
Ansible role for the internal mail relay.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+Ansible role for OpenCraft's internal mail relay
+================================================
+
+This Ansible role sets up a Postfix server that accepts mail from other internal servers.  Depending
+on the destination domain, the mail is either relayed to our internal incoming mail server, or to an
+external service for outgoing email.
+
+Clients connect with a TLS-encrypted connection and authenticate via SMTP authentication.  We use
+Dovecot on the server as SASL authentication backend.
+
+The Ansible variables for this role are documented in [defaults/main.yml](defaults/main.yml).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,39 @@
+---
+
+POSTFIX_HOSTNAME: "{{ inventory_hostname }}"
+POSTFIX_OPS_EMAIL: ops@example.com
+
+# TLS certificate and private key must be set in the configuration when running this role.
+# A self-signed certificate can be generated using a command similar to this one:
+#
+# openssl req -x509 -newkey rsa:4096 -nodes -keyout postfix.key -out postfix-cert.pem -days 3650 \
+#     -subj "/C=DE/ST=Berlin/L=Berlin/O=OpenCraft GmbH/OU=Org/CN=relay.net.opencraft.hosting"
+POSTFIX_TLS_CERT_CONTENT: ""
+POSTFIX_TLS_KEY_CONTENT: ""
+
+# The domain name of mail originating from the mail server (e.g. monitoring emails)
+POSTFIX_MAILNAME: example.com
+
+# The internal domain.  Mail for this domain will be sent to the internal mail server.
+POSTFIX_INTERNAL_DOMAIN: example.com
+POSTFIX_INTERNAL_MAIL_HOST: "[smtp.example.com]:25"
+
+# Outgoing mail server, specified in the format accepted by the Postfix SMTP client
+POSTFIX_RELAY_HOST: "[smtp.external-provider.com]:587"
+POSTFIX_RELAY_USER: user
+POSTFIX_RELAY_PASSWORD: password
+
+# Users who can authenticate against Postfix
+# Example:
+# POSTFIX_SASL_USERS:
+#   - user: jane
+#     password: skVMVk1Fbt3DaJbu
+#   - user: joe
+#     password: hunter2
+POSTFIX_SASL_USERS: []
+
+# Some configuration file paths; paths that shouldn't be changed have been hard-coded.
+POSTFIX_TLS_CERT: /etc/ssl/certs/postfix-cert.pem
+POSTFIX_TLS_KEY: /etc/ssl/private/postfix.key
+POSTFIX_SASL_CLIENT_PASSWORD_FILE: /etc/postfix/sasl/client-passwd
+POSTFIX_SASL_SERVER_PASSWORD_FILE: /etc/dovecot/private/users

--- a/files/dovecot-master.conf
+++ b/files/dovecot-master.conf
@@ -1,0 +1,9 @@
+# We only care about the auth service, so we replace the distribution config file by this minimal
+# version.
+
+service auth {
+  # Postfix smtp-auth
+  unix_listener /var/spool/postfix/private/auth {
+    mode = 0666
+  }
+}

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,93 @@
+---
+- name: install apt packages
+  apt:
+    name: "{{ item }}"
+  with_items:
+    - ca-certificates
+    - dovecot-core
+    - libsasl2-modules
+    - postfix
+    - sasl2-bin
+
+### Postfix configuration
+
+- name: copy TLS certificate
+  copy:
+    dest: "{{ POSTFIX_TLS_CERT }}"
+    content: "{{ POSTFIX_TLS_CERT_CONTENT }}"
+
+- name: copy TLS private key
+  copy:
+    dest: "{{ POSTFIX_TLS_KEY }}"
+    content: "{{ POSTFIX_TLS_KEY_CONTENT }}"
+    owner: root
+    group: ssl-cert
+    mode: "640"
+
+- name: write Postfix main.cf configuration file
+  template:
+    dest: /etc/postfix/main.cf
+    src: main.cf
+
+- name: write /etc/mailname
+  copy:
+    dest: /etc/mailname
+    content: "{{ POSTFIX_MAILNAME }}\n"
+
+- name: write /etc/aliases
+  template:
+    dest: /etc/aliases
+    src: aliases
+
+- name: configure SMTP client password
+  copy:
+    dest: "{{ POSTFIX_SASL_CLIENT_PASSWORD_FILE }}"
+    content: "{{ POSTFIX_RELAY_HOST }} {{POSTFIX_RELAY_USER}}:{{POSTFIX_RELAY_PASSWORD}}\n"
+    mode: "600"
+
+- name: call postmap on SMTP client password file
+  command: postmap "{{ POSTFIX_SASL_CLIENT_PASSWORD_FILE }}"
+
+### Dovecot configuration, used as Postfix SASL authentication backend
+
+- name: write Dovecot master configuration file
+  copy:
+    dest: /etc/dovecot/conf.d/10-master.conf
+    src: dovecot-master.conf
+
+- name: write Dovecot auth configuration file
+  template:
+    dest: /etc/dovecot/conf.d/10-auth.conf
+    src: dovecot-auth.conf
+
+- name: generate Dovecot password hashes
+  command: "doveadm pw -s SHA512-CRYPT -p {{ item.password }}"
+  register: dovecot_users
+  with_items: "{{ POSTFIX_SASL_USERS }}"
+
+- name: write Dovecot password file
+  copy:
+    dest: "{{ POSTFIX_SASL_SERVER_PASSWORD_FILE }}"
+    content: |
+      {% for item in dovecot_users.results -%}
+      {{ item.item.user }}:{{ item.stdout }}
+      {% endfor %}
+    owner: root
+    group: dovecot
+    mode: "640"
+
+### Restart services and open firewall
+
+- name: restart services
+  service:
+    name: "{{ item }}"
+    state: restarted
+  with_items:
+    - dovecot
+    - postfix
+
+- name: open SMTP port on the firewall
+  ufw:
+    rule: allow
+    port: 25
+    proto: tcp

--- a/templates/aliases
+++ b/templates/aliases
@@ -1,0 +1,2 @@
+root: {{ POSTFIX_OPS_EMAIL }}
+postmaster: root

--- a/templates/dovecot-auth.conf
+++ b/templates/dovecot-auth.conf
@@ -1,0 +1,22 @@
+# Space separated list of wanted authentication mechanisms:
+#   plain login digest-md5 cram-md5 ntlm rpa apop anonymous gssapi otp skey
+#   gss-spnego
+# NOTE: See also disable_plaintext_auth setting.
+auth_mechanisms = plain
+
+##
+## Password and user databases
+##
+
+passdb {
+  driver = passwd-file
+  # bcrypt does not seem to be available, so we went with the next best option we could find.
+  args = scheme=SHA512-CRYPT {{ POSTFIX_SASL_SERVER_PASSWORD_FILE }}
+}
+
+# We don't care about UID, GID and home directory, since we only use Dovecot to authenticate users
+# for postfix, so we can use static values here.
+userdb {
+  driver = static
+  args = uid=nobody gid=nogroup home=/home
+}

--- a/templates/main.cf
+++ b/templates/main.cf
@@ -1,0 +1,49 @@
+compatibility_level = 2
+
+myorigin = /etc/mailname
+myhostname = {{ POSTFIX_HOSTNAME }}
+inet_interfaces = all
+
+# Mail to receive locally. We should not receive local mail, but keep this here to avoid mail loops.
+mydestination = $myhostname, localhost.localdomain, localhost
+
+# Configure SASL authentication via dovecot
+smtpd_sasl_type = dovecot
+smtpd_sasl_path = private/auth
+smtpd_sasl_local_domain = $myhostname
+smtpd_sasl_security_options = noanonymous
+smtpd_sasl_auth_enable = yes
+
+# Relay mail to opencraft.com directly to mail.plebia.org
+relay_domains = {{ POSTFIX_INTERNAL_DOMAIN }} $mydestination
+relay_transport = relay:{{ POSTFIX_INTERNAL_MAIL_HOST }}
+
+# Relay mail from authenticated users and mail originating from local machine
+mynetworks_style = host
+smtpd_relay_restrictions = permit_mynetworks, permit_sasl_authenticated, reject_unauth_destination
+relayhost = {{ POSTFIX_RELAY_HOST }}
+smtp_sasl_auth_enable = yes
+smtp_sasl_password_maps = hash:{{ POSTFIX_SASL_CLIENT_PASSWORD_FILE }}
+smtp_sasl_security_options = noanonymous
+
+# TLS client settings
+smtp_tls_note_starttls_offer = yes
+smtp_tls_security_level = encrypt
+smtp_tls_mandatory_ciphers = high
+smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
+
+# TLS server settings
+smtpd_use_tls = yes
+smtpd_tls_cert_file = {{ POSTFIX_TLS_CERT }}
+smtpd_tls_key_file = {{ POSTFIX_TLS_KEY }}
+smtpd_tls_security_level = encrypt
+smtpd_tls_mandatory_ciphers = high
+smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
+smtpd_tls_loglevel = 1
+smtpd_tls_received_header = yes
+
+# Vaurious settings from the Ubuntu default configuration
+biff = no
+alias_maps = hash:/etc/aliases
+alias_database = hash:/etc/aliases
+recipient_delimiter = +


### PR DESCRIPTION
This is an implementation of an Ansible role for a new internal mail relay.  The relay receives email from other internal servers and sends it either to our incoming mail server or to an external outgoing mail server.  Eventually this server is supposed to replace our incoming mail server.